### PR TITLE
Add register_path_accessor to create new options for registering paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,27 @@ pd.Series(['a', 'b', 'c']).path / pd.Series(['1', '2', '3']).path
 # dtype: object
 ```
 
+3. `Path` object on the left-hand side of a join (Python < 3.8)
+
+Due to a [bug in Python](https://bugs.python.org/issue34775), this never gets handed off to us.
+
+```python
+Path("dir") / pd.Series(['a', 'b', 'c']).path
+
+#  TypeError: expected str, bytes or os.PathLike object, not PathAccessor
+```
+
+Workaround is to use a str on the left-hand side:
+
+```python
+str(Path("dir")) / pd.Series(['a', 'b', 'c']).path
+
+# 0    dir/a
+# 1    dir/b
+# 2    dir/c
+# dtype: object
+```
+
 
 That's all folks, enjoy!
 

--- a/pandas_path/__init__.py
+++ b/pandas_path/__init__.py
@@ -1,1 +1,3 @@
-from .accessor import PathAccessor  # noqa
+from .accessor import register_path_accessor  # noqa
+
+__all__ = [register_path_accessor]

--- a/pandas_path/accessor.py
+++ b/pandas_path/accessor.py
@@ -5,112 +5,130 @@ import numpy as np
 import pandas as pd
 
 
-@pd.api.extensions.register_series_accessor("path")
-@pd.api.extensions.register_index_accessor("path")
-class PathAccessor:
-    """Adds a `.path` accessor to Series and Index objects so that all of the methods
-        from pathlib.Path are available.
+def path_accessor_factory(path_class, *args, **kwargs):
+    class PathAccessor:
+        """Adds a `.path` accessor to Series and Index objects so that all of the methods
+            from pathlib.Path are available.
 
-        Register with pandas by importing. No other changes necessary.
+            Register with pandas by importing. No other changes necessary.
 
-        Note: Will return a `str` rather than a Path object so that joining with existing
-            dataframes, etc. will continue to work.
+            Note: Will return a `str` rather than a Path object so that joining with existing
+                dataframes, etc. will continue to work.
 
-        Note: May not be performant on extremely long lists since we cast to `Path`
-        for every operation.
+            Note: May not be performant on extremely long lists since we cast to `Path`
+            for every operation.
 
-    Raises
-    ------
-    AttributeError
-        If the method we try to use on the accessor is not a function or property or
-        is not an attribute on Path, raise an AttributeError.
-    """
+        Raises
+        ------
+        AttributeError
+            If the method we try to use on the accessor is not a function or property or
+            is not an attribute on Path, raise an AttributeError.
+        """
 
-    def __init__(self, pandas_obj):
-        self._validate(pandas_obj)
-        self._obj = pandas_obj
+        def __init__(self, pandas_obj):
+            self._validate(pandas_obj)
+            self._obj = pandas_obj
 
-    @staticmethod
-    def _validate(obj):
-        [Path(x) for x in obj.values]
+        @staticmethod
+        def _validate(obj):
+            [path_class(x, *args, **kwargs) for x in obj.values]
 
-    def __getattr__(self, attr):
-        apply_series = self._obj.to_series() if isinstance(self._obj, pd.Index) else self._obj
+        @staticmethod
+        def _to_path_object(path_str):
+            return path_class(path_str, *args, **kwargs)
 
-        # check the type of this attribute on a Path object
-        attr_type = getattr(type(Path()), attr, None)
+        def __getattr__(self, attr):
+            apply_series = self._obj.to_series() if isinstance(self._obj, pd.Index) else self._obj
 
-        # if we're asking for a property, do the calculation and return the result
-        if isinstance(attr_type, property):
+            # check the type of this attribute on a Path object
+            if isinstance(self._obj.values[0], path_class):
+                attr_type = getattr(type(self._obj.values[0]), attr, None)
+            else:
+                attr_type = getattr(type(self._to_path_object("")), attr, None)
 
-            def _to_apply(x):
-                res = getattr(Path(x), attr)
-                return res if not isinstance(res, Path) else str(res)
+            # if we're asking for a property, do the calculation and return the result
+            if isinstance(attr_type, property):
 
-            return apply_series.apply(_to_apply)
+                def _to_apply(x):
+                    res = getattr(self._to_path_object(x), attr)
+                    return res if not isinstance(res, path_class) else str(res)
 
-        # if we're asking for a function, return a callable method
-        elif isinstance(attr_type, (FunctionType, MethodType, LambdaType)):
+                return apply_series.apply(_to_apply)
 
-            def _callable(*args, **kwargs):
-                if len(args) == 1 and isinstance(
-                    args[0], (list, tuple, np.ndarray, pd.Series, pd.Index)
-                ):
-                    other = args[0]
-                    return self._elementwise(other, attr)
+            # if we're asking for a function, return a callable method
+            elif isinstance(attr_type, (FunctionType, MethodType, LambdaType)):
 
-                else:
+                def _callable(*args, **kwargs):
+                    if len(args) == 1 and isinstance(
+                        args[0], (list, tuple, np.ndarray, pd.Series, pd.Index)
+                    ):
+                        other = args[0]
+                        return self._elementwise(other, attr)
 
-                    def _to_apply(x):
-                        res = getattr(Path(x), attr)(*args, **kwargs)
-                        return res if not isinstance(res, Path) else str(res)
+                    else:
 
-                    return apply_series.apply(_to_apply)
+                        def _to_apply(x):
+                            res = getattr(self._to_path_object(x), attr)(*args, **kwargs)
+                            return res if not isinstance(res, path_class) else str(res)
 
-            return _callable
+                        return apply_series.apply(_to_apply)
 
-        else:
-            raise AttributeError(f"Can't find or handle path attribute {attr}.")
+                return _callable
 
-    def _elementwise(self, other, attr):
-        if isinstance(other, PathAccessor):
-            other = other._obj
+            else:
+                raise AttributeError(f"Can't find or handle path attribute {attr}.")
 
-        other_array = np.array(other)
+        def _elementwise(self, other, attr):
+            if isinstance(other, PathAccessor):
+                other = other._obj
 
-        if other_array.ndim > 1:
-            raise ValueError(
-                "Can only do an elementwise operations with a 1d array, list, or Series."
+            other_array = np.array(other)
+
+            if other_array.ndim > 1:
+                raise ValueError(
+                    "Can only do an elementwise operations with a 1d array, list, or Series."
+                )
+
+            if other_array.shape[0] != len(self._obj):
+                raise ValueError(
+                    "Can only do an elementwise operation with arrays of the same length."
+                )
+
+            def _to_apply(this_elem, other_elem):
+                res = getattr(self._to_path_object(this_elem), attr)(other_elem)
+                return res if not isinstance(res, path_class) else str(res)
+
+            elementwise_result = pd.Series(
+                [
+                    _to_apply(this_elem, other_elem)
+                    for this_elem, other_elem in zip(self._obj.values, other_array)
+                ],
+                index=self._obj.index,
             )
 
-        if other_array.shape[0] != len(self._obj):
-            raise ValueError(
-                "Can only do an elementwise operation with arrays of the same length."
-            )
+            return elementwise_result
 
-        def _to_apply(this_elem, other_elem):
-            res = getattr(Path(this_elem), attr)(other_elem)
-            return res if not isinstance(res, Path) else str(res)
+        def _path_join(self, other, side):
+            if isinstance(other, (list, tuple, np.ndarray, pd.Series, pd.Index, PathAccessor)):
+                return self._elementwise(other, side)
+            else:
+                return self.__getattr__(side)(other)
 
-        elementwise_result = pd.Series(
-            [
-                _to_apply(this_elem, other_elem)
-                for this_elem, other_elem in zip(self._obj.values, other_array)
-            ],
-            index=self._obj.index,
-        )
+        # operators don't override correctly unless defined
+        def __truediv__(self, other):
+            return self._path_join(other, "__truediv__")
 
-        return elementwise_result
+        def __rtruediv__(self, other):
+            return self._path_join(other, "__rtruediv__")
 
-    def _path_join(self, other, side):
-        if isinstance(other, (list, tuple, np.ndarray, pd.Series, pd.Index, PathAccessor)):
-            return self._elementwise(other, side)
-        else:
-            return self.__getattr__(side)(other)
+    return PathAccessor
 
-    # operators don't override correctly unless defined
-    def __truediv__(self, other):
-        return self._path_join(other, "__truediv__")
 
-    def __rtruediv__(self, other):
-        return self._path_join(other, "__rtruediv__")
+def register_path_accessor(accessor_name, path_class, *args, **kwargs):
+    accessor_class = path_accessor_factory(path_class, *args, **kwargs)
+    pd.api.extensions.register_series_accessor(accessor_name)(accessor_class)
+    pd.api.extensions.register_index_accessor(accessor_name)(accessor_class)
+
+
+# default to registering `Path` to `path`
+register_path_accessor("path", Path)

--- a/pandas_path/tests.py
+++ b/pandas_path/tests.py
@@ -106,10 +106,11 @@ def test_operators(sample_series, sample_paths):
         (sample_series.path.parent.path / "new_sub_folder").path / "new_file.txt"
     ).tolist() == expected
 
-    # left-hand path object
-    assert (
-        (Path("new_folder") / sample_series.path) == ("new_folder" + os.sep + sample_series)
-    ).all()
+    # left-hand path object (only supported Python > 3.7 because of https://bugs.python.org/issue34775)
+    if sys.version_info.major >= 3 and sys.version_info.minor >= 8:
+        assert (
+            (Path("new_folder") / sample_series.path) == ("new_folder" + os.sep + sample_series)
+        ).all()
 
     # right-hand path object
     assert (

--- a/pandas_path/tests.py
+++ b/pandas_path/tests.py
@@ -162,3 +162,6 @@ def test_custom_accessor(pd, sample_paths):
     )
 
     assert (win_series.win.parent == (win_series.str.rsplit("\\", 1).str[0])).all()
+
+    assert win_series.win.__name__ == "PureWindowsPathAccessor"
+    assert "PureWindowsPath" in win_series.win.__doc__

--- a/pandas_path/tests.py
+++ b/pandas_path/tests.py
@@ -116,7 +116,8 @@ def test_operators(sample_series, sample_paths):
     assert (
         (sample_series.path.parent.path / Path("new_file.txt"))
         == (
-            (sample_series.path.parent.replace(".", "") + os.sep).str.lstrip("./") + "new_file.txt"
+            (sample_series.path.parent.replace(".", "") + os.sep).str.lstrip("." + os.sep)
+            + "new_file.txt"
         )
     ).all()
 


### PR DESCRIPTION
 - Adds `register_path_accessor` to create custom accessors for objects that implement `Path`
 - Update readme with examples
 - Update readme badges after #3 
 - Add tests for `Path` of RHS and LHS for joining

Closes #1 